### PR TITLE
Remove android-maven, replace compile with implementation and a small change in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,14 @@ Installation within android Studio is pretty easy, just add these lines to your 
 2. Add the dependency
 ```gradle
 	dependencies {
-	        compile 'com.github.Willena:Android_PhoneNumber_Input:1.0'
+	        implementation 'com.github.Willena:Android_PhoneNumber_Input:1.3'
 	}
 ```
+
+### Note about v1.3
+
+In order for v1.3 to work correctly you might have to add the module manually
+
 ## How to use
 
 The widget can be used in your .xml layout, here is an example :

--- a/phoneinputview/build.gradle
+++ b/phoneinputview/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
 
 group = 'com.github.willena'
 
@@ -18,7 +17,7 @@ android {
 
 dependencies {
     api fileTree(include: ['*.jar'], dir: 'libs')
-    androidTestCompile('androidx.test.espresso:espresso-core:3.1.0', {
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     implementation 'androidx.appcompat:appcompat:1.2.0'


### PR DESCRIPTION
I did the following:

- Updated README to replace compile with implementation and v1.0 with v1.3. I also added a note that they might have to install v1.3 "manually" in order to work (due to #2)
- Removed `apply plugin: 'com.github.dcendents.android-maven'` because it was causing this error for me*: 
![image](https://user-images.githubusercontent.com/62189294/103700020-7e7ca800-4fac-11eb-8f58-1a8f701e04a8.png)

- Replaced `androidTestCompile` with `androidTestImplementation`

Please verify, thank you

*Ok, yesterday I was moving around folders yesterday so that might be just for me...
