### PR TITLE
Add the ability to control the hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ There are some useful method such as :
   * INTERNATIONAL
   * NATIONAL
   * RFC3966
-- **setCountry** : this method the the country on the spinner
+- **setCountry** : this method sets the country on the spinner
+- **setDisplayMobileHint** : this method sets the phone number type that will be displayed as hint
 - **setPhoneNumber** : this method sets the number and the country.
 - **getCountryList** : this method returns the list of availale country
 
@@ -77,6 +78,7 @@ CountryConfigurator config = new CountryConfigurator();
 config.setDisplayFlag(true);
 config.setDisplayCountryCode(true);
 config.setDisplayDialingCode(true);
+config.setDisplayMobileHint(true); //Set the phone number type that will be displayed as hint (set to true to display a mobile number as hint / set to true to display a fixed-line number as hint / set to null to hide the hint)
 config.setDefaultCountry("FR"); //Set the default country that will be selected when loading
 ``` 
 

--- a/phoneinputview/src/main/java/com/github/willena/phoneinputview/CountryConfigurator.java
+++ b/phoneinputview/src/main/java/com/github/willena/phoneinputview/CountryConfigurator.java
@@ -9,21 +9,19 @@ public class CountryConfigurator {
     private Boolean displayFlag;
     private Boolean displayCountryCode;
     private Boolean displayDialingCode;
+	private Boolean displayMobileHint;
     private String defaultCountry;
 
     public CountryConfigurator() {
         displayFlag = true;
         displayCountryCode = true;
         displayDialingCode = true;
+		displayMobileHint = true;
         defaultCountry = null;
     }
 
     public void setDefaultCountry(String defaultCode) {
         this.defaultCountry = defaultCode;
-    }
-
-    public String getDefaultCountry() {
-        return defaultCountry;
     }
 
     public void setDisplayCountryCode(Boolean displayCountryCode) {
@@ -37,6 +35,10 @@ public class CountryConfigurator {
     public void setDisplayFlag(Boolean displayFlag) {
         this.displayFlag = displayFlag;
     }
+	
+	public void setDisplayMobileHint(Boolean displayMobileHint){
+		this.displayMobileHint = displayMobileHint;
+	}
 
     public Boolean getDisplayCountryCode() {
         return displayCountryCode;
@@ -48,5 +50,13 @@ public class CountryConfigurator {
 
     public Boolean getDisplayFlag() {
         return displayFlag;
+    }
+	
+	public Boolean getDisplayMobileHint() {
+		return displayMobileHint;
+	}
+	
+	public String getDefaultCountry() {
+        return defaultCountry;
     }
 }

--- a/phoneinputview/src/main/java/com/github/willena/phoneinputview/PhoneInputView.java
+++ b/phoneinputview/src/main/java/com/github/willena/phoneinputview/PhoneInputView.java
@@ -101,7 +101,15 @@ public class PhoneInputView extends LinearLayout {
             public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
                 String code = ((CountryInfo) spinnerView.getSelectedItem()).getCode();
                 Log.d("PHONE_DIALOG", "onItemSelected: " + code);
-                textInput.setHint(phoneUtil.format(phoneUtil.getExampleNumberForType(((CountryInfo) spinnerView.getSelectedItem()).getCode(), PhoneNumberUtil.PhoneNumberType.FIXED_LINE_OR_MOBILE), PhoneNumberUtil.PhoneNumberFormat.NATIONAL));
+                try {
+                    if (config.getDisplayMobileHint()){
+                        textInput.setHint(phoneUtil.format(phoneUtil.getExampleNumberForType(((CountryInfo) spinnerView.getSelectedItem()).getCode(), PhoneNumberUtil.PhoneNumberType.MOBILE), PhoneNumberUtil.PhoneNumberFormat.NATIONAL));
+                    } else {
+                        textInput.setHint(phoneUtil.format(phoneUtil.getExampleNumberForType(((CountryInfo) spinnerView.getSelectedItem()).getCode(), PhoneNumberUtil.PhoneNumberType.FIXED_LINE), PhoneNumberUtil.PhoneNumberFormat.NATIONAL));
+                    }
+                } catch (NullPointerException e){
+                    textInput.setHint(null);
+                }
                 textInput.setText(textInput.getText());
                 triggerCountryChange(code);
             }


### PR DESCRIPTION
I think that it would be nice to be able to control weather the hint that gets displayed is a mobile number or a landline (or if we do not want to show one at all). This is what this change does.

We can now do:

- `config.setDisplayMobileHint(true);` to show a mobile number as a hint

- `config.setDisplayMobileHint(false);` to show a fixed-line number as a hint

- `config.setDisplayMobileHint(null);` to hide the hint

Please verify, thank you